### PR TITLE
Fixing default URL

### DIFF
--- a/chrome/content/scripts/zoteroscihub.js
+++ b/chrome/content/scripts/zoteroscihub.js
@@ -2,7 +2,7 @@ Zotero.Scihub = {
 	scihub_url: function() {
 		// Set default if not set.
 		if(Zotero.Prefs.get('zoteroscihub.scihub_url') === undefined) {
-			Zotero.Prefs.set('zoteroscihub.scihub_url', 'https://sci-hub.tw')
+			Zotero.Prefs.set('zoteroscihub.scihub_url', 'https://sci-hub.tw/')
 		}
 		return Zotero.Prefs.get('zoteroscihub.scihub_url')
 	},
@@ -129,7 +129,7 @@ Zotero.Scihub = {
 		var DOI = item.getField('DOI');
 		var url = "";
 		if(DOI && (typeof DOI == 'string') && DOI.length > 0) {
-			url = baseURL+DOI;
+			url = baseURL+'/'+DOI;
 		}
 
 		// If not using sci-hub.tw ssl is disabled due to invalid certs.


### PR DESCRIPTION
Adding needed `/` in url

A `/` is needed to separete the base url of sci-hub and the doi. I added the slash to the default URL, and changed the behaviour, so that a slash is automatically added to the base url. Note that multiple `/` are allowed in the URL.